### PR TITLE
Fixed updating plugins

### DIFF
--- a/Sketch Toolbox/PluginManager.m
+++ b/Sketch Toolbox/PluginManager.m
@@ -87,7 +87,7 @@
             plugin.stars = [dataDict[@"stargazers_count"] intValue];
             
             NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
-            [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZ"];
+            [formatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZ"];
             NSLocale *posix = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
             [formatter setLocale:posix];
             NSDate *pushed_date = [formatter dateFromString:dataDict[@"pushed_at"]];


### PR DESCRIPTION
Was using the wrong date format GitHub “pushed_at”, causing plugins to
not be updated when a new version was pushed to GitHub.